### PR TITLE
[AMA-008] - Add cascade update and delete for district

### DIFF
--- a/src/city/city.dto.ts
+++ b/src/city/city.dto.ts
@@ -5,7 +5,7 @@ import { District } from '../district/district.entity';
 export class CreateCityDto {
   @IsString()
   @IsNotEmpty()
-  stateCode: string;
+  stateId: string;
 
   @IsString()
   @IsNotEmpty()

--- a/src/city/city.entity.ts
+++ b/src/city/city.entity.ts
@@ -2,7 +2,7 @@ import mongoose, { Schema, Document } from 'mongoose';
 import { District, DistrictSchema } from '../district/district.entity';
 
 export interface City {
-  stateCode: string | number;
+  stateId: string | number;
   countryCode: string;
   postalCodes: string[];
   cityId: number;
@@ -13,7 +13,7 @@ export interface City {
 export interface CityDocument extends City, Document {}
 
 export const CitySchema = new Schema<CityDocument>({
-  stateCode: { type: Schema.Types.Mixed, required: true },
+  stateId: { type: Schema.Types.Mixed, required: true },
   countryCode: { type: String, required: true },
   postalCodes: { type: [String], required: true },
   cityId: { type: Number, required: true },

--- a/src/district/district.dto.ts
+++ b/src/district/district.dto.ts
@@ -1,5 +1,4 @@
 import { IsString, IsNotEmpty, IsNumber } from 'class-validator';
-import { PartialType } from '@nestjs/mapped-types';
 
 export class CreateDistrictDto {
   @IsString()
@@ -7,10 +6,11 @@ export class CreateDistrictDto {
   countryCode: string;
 
   @IsString()
+  @IsNotEmpty()
   cityId: string;
 
   @IsString()
-  postalCode: string;
+  postalCode: string | null;
 
   @IsString()
   @IsNotEmpty()
@@ -26,4 +26,4 @@ export class CreateDistrictDto {
   accuracy?: number | null;
 }
 
-export class UpdateDistrictDto extends PartialType(CreateDistrictDto) {}
+export class UpdateDistrictDto extends (CreateDistrictDto) {}

--- a/src/district/district.dto.ts
+++ b/src/district/district.dto.ts
@@ -7,7 +7,10 @@ export class CreateDistrictDto {
   countryCode: string;
 
   @IsString()
-  postalCode?: string;
+  cityId: string;
+
+  @IsString()
+  postalCode: string;
 
   @IsString()
   @IsNotEmpty()

--- a/src/district/district.entity.ts
+++ b/src/district/district.entity.ts
@@ -3,11 +3,11 @@ import mongoose, { Schema, Document } from 'mongoose';
 export interface District {
   countryCode: string;
   cityId: string;
-  postalCode: string;
+  postalCode: string | null;
   name: string;
-  latitude: number | null;
-  longitude: number | null;
-  accuracy: number | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  accuracy?: number | null;
 }
 
 export interface DistrictDocument extends District, Document {}
@@ -15,7 +15,7 @@ export interface DistrictDocument extends District, Document {}
 export const DistrictSchema = new Schema<DistrictDocument>({
   countryCode: { type: String, required: true },
   cityId: { type: String, required: true },
-  postalCode: { type: String, required: true },
+  postalCode: { type: String },
   name: { type: String, required: true },
   latitude: { type: Number, default: null },
   longitude: { type: Number, default: null },

--- a/src/district/district.entity.ts
+++ b/src/district/district.entity.ts
@@ -2,7 +2,8 @@ import mongoose, { Schema, Document } from 'mongoose';
 
 export interface District {
   countryCode: string;
-  postalCode?: string;
+  cityId: string;
+  postalCode: string;
   name: string;
   latitude: number | null;
   longitude: number | null;
@@ -13,6 +14,7 @@ export interface DistrictDocument extends District, Document {}
 
 export const DistrictSchema = new Schema<DistrictDocument>({
   countryCode: { type: String, required: true },
+  cityId: { type: String, required: true },
   postalCode: { type: String, required: true },
   name: { type: String, required: true },
   latitude: { type: Number, default: null },

--- a/src/district/district.module.ts
+++ b/src/district/district.module.ts
@@ -3,10 +3,14 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { DistrictController } from './district.controller';
 import { DistrictService } from './district.service';
 import { DistrictModel, DistrictSchema } from './district.entity';
+import { CitySchema } from '../city/city.entity';
 
 @Module({
   imports: [
-    MongooseModule.forFeature([{ name: 'District', schema: DistrictSchema }]),
+    MongooseModule.forFeature([
+      { name: 'District', schema: DistrictSchema },
+      { name: 'City', schema: CitySchema },
+    ]),
   ],
   controllers: [DistrictController],
   providers: [DistrictService, DistrictModel],

--- a/src/district/district.service.ts
+++ b/src/district/district.service.ts
@@ -26,16 +26,20 @@ export class DistrictService {
   async create(
     createDistrictDto: CreateDistrictDto,
   ): Promise<DistrictDocument> {
-    const city = await this.cityModel.findOne({
-      cityId: createDistrictDto.cityId,
-      countryCode: createDistrictDto.countryCode,
-    }).exec();
-  
+    const city = await this.cityModel
+      .findOne({
+        cityId: createDistrictDto.cityId,
+        countryCode: createDistrictDto.countryCode,
+      })
+      .exec();
+
     if (!city) {
       throw new Error('City not found');
     }
 
-    const existingDistrict = city.districts.find(district => district.name === createDistrictDto.name);
+    const existingDistrict = city.districts.find(
+      (district) => district.name === createDistrictDto.name,
+    );
     if (existingDistrict) {
       throw new Error('District already exists in the city');
     }
@@ -57,12 +61,75 @@ export class DistrictService {
     id: string,
     updateDistrictDto: UpdateDistrictDto,
   ): Promise<DistrictDocument> {
+    const { cityId, countryCode } = updateDistrictDto;
+
+    if (!cityId || !countryCode) {
+      throw new Error('cityId and countryCode are required');
+    }
+
+    const city = await this.cityModel.findOne({ cityId, countryCode }).exec();
+
+    if (!city) {
+      throw new Error(
+        `City with cityId ${cityId} and countryCode ${countryCode} not found`,
+      );
+    }
+
+    const currDistrict = await this.districtModel.findOne({ _id: id }).exec();
+
+    if (!currDistrict) {
+      throw new Error(`District with id ${id} not found`);
+    }
+
+    const cityDistricts = city.districts.filter(
+      (_district) =>
+        _district.countryCode !== currDistrict.countryCode &&
+        _district.cityId !== currDistrict.cityId &&
+        _district.name !== currDistrict.name &&
+        _district.postalCode !== currDistrict.postalCode,
+    );
+    const cityPostalCodes = city.postalCodes.filter(
+      (_postalCodes) => _postalCodes !== currDistrict.postalCode,
+    );
+
+    cityDistricts.push(updateDistrictDto);
+    cityPostalCodes.push(updateDistrictDto.postalCode);
+    city.districts = cityDistricts;
+    city.postalCodes = cityPostalCodes;
+
+    await city.save();
+
     return this.districtModel
       .findByIdAndUpdate(id, updateDistrictDto, { new: true })
       .exec();
   }
 
   async delete(id: string): Promise<DistrictDocument> {
+    const district = await this.districtModel.findById(id).exec();
+
+    if (!district) {
+      throw new Error('District not found');
+    }
+
+    const { cityId, postalCode } = district;
+
+    const city = await this.cityModel.findById(cityId).exec();
+
+    if (!city) {
+      throw new Error('City not found');
+    }
+
+    city.districts = city.districts.filter(
+      (_district) =>
+        _district.countryCode !== district.countryCode &&
+        _district.cityId !== district.cityId &&
+        _district.name !== district.name &&
+        _district.postalCode !== district.postalCode,
+    );
+    city.postalCodes = city.postalCodes.filter((_postalCode) => _postalCode !== postalCode);
+
+    await city.save();
+
     return this.districtModel.findByIdAndDelete(id).exec();
   }
 }


### PR DESCRIPTION
Cascade update and delete for district

**ACCEPTANCE CRITERIA**
- When creating, updating and deleting a district, update the referenced city's `postalCodes` and `districts` fields.
- Rename city `stateCode` field to `stateId`.